### PR TITLE
feat(seeders): implement user seeders for development and testing

### DIFF
--- a/database/seeders/user_seeder.ts
+++ b/database/seeders/user_seeder.ts
@@ -1,0 +1,35 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import hash from '@adonisjs/core/services/hash'
+import db from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+export default class extends BaseSeeder {
+  async run() {
+    // Hash les mots de passe
+    const adminPassword = await hash.make('password')
+    const userPassword = await hash.make('password')
+
+    await db.table('users').multiInsert([
+      {
+        username: 'admin',
+        email: 'admin@example.com',
+        password: adminPassword,
+        role_id: 3, // ADMIN role
+        newsletter_consent: false,
+        terms_accepted_at: DateTime.now().toSQL(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+      {
+        username: 'user',
+        email: 'user@example.com', 
+        password: userPassword,
+        role_id: 1, // USER role
+        newsletter_consent: false,
+        terms_accepted_at: DateTime.now().toSQL(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ])
+  }
+}


### PR DESCRIPTION
## Summary
- Implement UserSeeder to create admin and standard user accounts for development/testing
- Add two test accounts with proper password hashing and role assignment
- Follow existing seeder patterns and DDD architecture

## Changes
- ✅ **Admin user**: `admin@example.com` / `admin` / `password` (ADMIN role)
- ✅ **Standard user**: `user@example.com` / `user` / `password` (USER role) 
- ✅ Passwords properly hashed using `Hash.make()`
- ✅ Newsletter consent set to false by default
- ✅ Terms accepted timestamp configured
- ✅ Executable via `node ace db:seed` command

## Testing
- [x] Seeder executes successfully without errors
- [x] Users created with correct data in database
- [x] Passwords properly hashed
- [x] Roles correctly assigned (admin: id=3, user: id=1)
- [x] Ready for manual login testing

## Architecture
- Follows existing seeder patterns (`role_seeder.ts`)
- Maintains DDD architecture and conventions
- Uses AdonisJS services (Hash, DateTime, DB)
- Consistent with project coding standards

Resolves #47

🤖 Generated with [Claude Code](https://claude.ai/code)